### PR TITLE
Ubuntu integration tests using Vagrant VM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
-NOTES.md
+.vagrant
+
+# saltstack
 Saltfile
 pillar/personal
+
+# others
+NOTES.md

--- a/README.md
+++ b/README.md
@@ -146,6 +146,9 @@ The easiest way to start is by installing salt via [bootstrap script](https://gi
 
   # check if the service is stopped
   sudo systemctl status salt-minion
+
+  # ensure the service will not start on the next reboot
+  sudo systemctl disable salt-minion
   ```
 </details>
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,67 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+
+  # config.vm.provider "virtualbox"
+  config.vm.synced_folder ".", "/vagrant", disabled: true
+
+  config.vm.define "ubuntu" do |ubuntu|
+    ubuntu.vm.box = "generic/ubuntu2204"
+    ubuntu.vm.box_version = "4.3.12"
+
+    ubuntu.vm.provider :virtualbox do |vb|
+      vb.name = "ubuntu"
+      vb.memory = 2048
+      vb.cpus = 4
+    end
+
+    ubuntu.vm.provision "shell", inline: <<-SHELL
+      sudo apt-get update -y
+    SHELL
+  end
+
+  config.vm.define "ubuntu-gui" do |ubuntu|
+    ubuntu.vm.box = "ubuntu/jammy64"
+    ubuntu.vm.box_version = "20240614.0.0"
+    ubuntu.vm.synced_folder ".", "/opt/salt-local-dev", automount: true
+
+    ubuntu.vm.provider :virtualbox do |vb|
+      vb.name = "ubuntu-gui"
+      vb.memory = 2048
+      vb.cpus = 4
+      vb.gui = true
+
+      # https://developer.hashicorp.com/vagrant/docs/providers/virtualbox/configuration
+      vb.customize ['modifyvm', :id, '--graphicscontroller', 'vmsvga']
+      vb.customize ['modifyvm', :id, '--vram', '16']
+      vb.customize ["modifyvm", :id, "--clipboard-mode", "bidirectional"]
+      vb.customize ["modifyvm", :id, "--draganddrop", "bidirectional"]
+    end
+
+    ubuntu.vm.provision "shell", inline: <<-SHELL
+      sudo apt-get update -y
+
+      echo "#################### Ubuntu GUI"
+      sudo apt-get install -y ubuntu-desktop
+
+      echo "#################### SALT"
+      wget -O /tmp/bootstrap-salt.sh https://bootstrap.saltproject.io
+      test $(sha256sum /tmp/bootstrap-salt.sh | awk '{print $1}') \
+      = $(wget -qO- https://bootstrap.saltproject.io/sha256) \
+      && echo "OK" || echo "File does not match checksum"
+
+      # install salt
+      ## -P : Allow pip based installations
+      ## -X : Do not start daemons after installation (to favor our masterless approach)
+      sudo sh /tmp/bootstrap-salt.sh -X -P stable 3006.8
+
+      # For Debian distros, like Ubuntu, we will need to manually stop the service
+      sudo systemctl stop salt-minion
+      sudo systemctl status salt-minion
+
+      echo "#################### DONE"
+      sudo shutdown --reboot +1m “Initial setup is now completed. The VM will reboot in 1 minute!”
+    SHELL
+  end
+end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -61,7 +61,7 @@ Vagrant.configure("2") do |config|
       sudo systemctl status salt-minion
 
       echo "#################### DONE"
-      sudo shutdown --reboot +1m “Initial setup is now completed. The VM will reboot in 1 minute!”
+      sudo shutdown --reboot +1 “Initial setup is now completed. The VM will reboot in 1 minute!”
     SHELL
   end
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -24,7 +24,8 @@ Vagrant.configure("2") do |config|
   config.vm.define "ubuntu-gui" do |ubuntu|
     ubuntu.vm.box = "ubuntu/jammy64"
     ubuntu.vm.box_version = "20240614.0.0"
-    ubuntu.vm.synced_folder ".", "/opt/salt-local-dev", automount: true
+    ubuntu.vm.synced_folder ".", "/opt/salt-local-dev",
+      type: "rsync", rsync__auto: true, rsync__exclude: ['./Saltfile']
 
     ubuntu.vm.provider :virtualbox do |vb|
       vb.name = "ubuntu-gui"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -59,7 +59,10 @@ Vagrant.configure("2") do |config|
 
       # For Debian distros, like Ubuntu, we will need to manually stop the service
       sudo systemctl stop salt-minion
+      sudo systemctl disable salt-minion
       sudo systemctl status salt-minion
+
+      sudo salt-call --local --file-root /opt/salt-local-dev/salt --pillar-root /opt/salt-local-dev/pillar state.sls salt.minion
 
       echo "#################### DONE"
       sudo shutdown --reboot +1 “Initial setup is now completed. The VM will reboot in 1 minute!”

--- a/local/Saltfile.local
+++ b/local/Saltfile.local
@@ -1,0 +1,4 @@
+salt-call:
+  local: True
+  log_level: warning
+  state_output: changes

--- a/local/pillar-personal-init.sls
+++ b/local/pillar-personal-init.sls
@@ -1,0 +1,9 @@
+#!yaml
+
+personal:
+  account:
+    user:
+      name: Vagrant
+      email: vagrant@local
+      username: vagrant
+      group: vagrant

--- a/pillar/top.sls
+++ b/pillar/top.sls
@@ -3,6 +3,7 @@ base:
     - personal
     - python
     - vscode
+    - vagrant
     - zsh
 
   G@kernel:Linux:

--- a/pillar/vagrant/init.sls
+++ b/pillar/vagrant/init.sls
@@ -1,0 +1,5 @@
+#!yaml
+
+vagrant:
+  plugins:
+    - vagrant-vbguest

--- a/salt/hypervisor/virtualbox/config.sls
+++ b/salt/hypervisor/virtualbox/config.sls
@@ -1,3 +1,5 @@
+{% from "hypervisor/virtualbox/map.jinja" import virtualbox with context %}
+
 {% if salt.grains.get('os') == "Ubuntu" %}
 
 virtualbox-config-vboxdrv:
@@ -8,5 +10,16 @@ virtualbox-config-vboxdrv:
         cmd: VBoxManage --version | grep 'The vboxdrv kernel module is not loaded'
         python_shell: True
         output_loglevel: quiet # prevent printing expected log errors
+
+virtualbox-config-group:
+  group.present:
+    - name: vboxusers
+    - addusers: {{ virtualbox.addusers }}
+
+virtualbox-config-message:
+  test.succeed_with_changes:
+    - name: "You may need to log out or restart so the group membership is re-evaluated."
+    - onchanges:
+      - group: virtualbox-config-group
 
 {% endif %}

--- a/salt/hypervisor/virtualbox/config.sls
+++ b/salt/hypervisor/virtualbox/config.sls
@@ -1,0 +1,12 @@
+{% if salt.grains.get('os') == "Ubuntu" %}
+
+virtualbox-config-vboxdrv:
+  cmd.run:
+    - name: /sbin/vboxconfig
+    - onlyif:
+      - fun: cmd.run
+        cmd: VBoxManage --version | grep 'The vboxdrv kernel module is not loaded'
+        python_shell: True
+        output_loglevel: quiet # prevent printing expected log errors
+
+{% endif %}

--- a/salt/hypervisor/virtualbox/init.sls
+++ b/salt/hypervisor/virtualbox/init.sls
@@ -1,2 +1,3 @@
 include:
   - .install
+  - .config

--- a/salt/hypervisor/virtualbox/install.sls
+++ b/salt/hypervisor/virtualbox/install.sls
@@ -1,11 +1,5 @@
 {% if salt.grains.get('os') == "Ubuntu" %}
 
-virtualbox-dependencies:
-  pkg.latest:
-    - pkgs:
-      - linux-headers-{{ salt.grains.get('kernelrelease') }}
-      - dkms
-
 virtualbox-add-apt-gpg-key: # favor gpg considering apt-key is depricated
   cmd.run:
     - name: curl -sS https://www.virtualbox.org/download/oracle_vbox_2016.asc | sudo gpg --yes --dearmor --output /usr/share/keyrings/oracle-virtualbox-2016.gpg
@@ -21,7 +15,9 @@ virtualbox-add-apt-repository:
 
 virtualbox-install-latest:
   pkg.latest:
-    - name: virtualbox-7.0
+    - pkgs:
+      - virtualbox-6.1
+      - virtualbox-dkms
 
 {% elif salt.grains.get('kernel') == "Darwin" %}
 

--- a/salt/hypervisor/virtualbox/install.sls
+++ b/salt/hypervisor/virtualbox/install.sls
@@ -1,5 +1,11 @@
 {% if salt.grains.get('os') == "Ubuntu" %}
 
+virtualbox-dependencies:
+  pkg.latest:
+    - pkgs:
+      - linux-headers-{{ salt.grains.get('kernelrelease') }}
+      - dkms
+
 virtualbox-add-apt-gpg-key: # favor gpg considering apt-key is depricated
   cmd.run:
     - name: curl -sS https://www.virtualbox.org/download/oracle_vbox_2016.asc | sudo gpg --yes --dearmor --output /usr/share/keyrings/oracle-virtualbox-2016.gpg

--- a/salt/hypervisor/virtualbox/map.jinja
+++ b/salt/hypervisor/virtualbox/map.jinja
@@ -1,0 +1,23 @@
+{% from "personal/map.jinja" import account with context %}
+
+
+{# VIRTUALBOX #}
+{% set _virtualbox_by_kernel = salt['grains.filter_by']({
+
+  'default': { },
+
+  'Darwin': { },
+
+  'Linux': { },
+
+}, grain='kernel') %}
+
+
+{# EXTRA #}
+{% set _additional_data = {
+  'addusers': [ account.username ],
+} %}
+
+
+{# EXPOSE #}
+{% set virtualbox = salt.slsutil.merge(_virtualbox_by_kernel, _additional_data) %}

--- a/salt/salt/minion/config/files/minion.d/minion.conf.jinja
+++ b/salt/salt/minion/config/files/minion.d/minion.conf.jinja
@@ -1,4 +1,2 @@
-file_roots:
-  {{ salt.config.get('file_roots') | dict_to_sls_yaml_params | indent(2) }}
-pillar_roots:
-  {{ salt.config.get('pillar_roots') | dict_to_sls_yaml_params | indent(2) }}
+file_roots: {{ salt.config.get('file_roots') }}
+pillar_roots: {{ salt.config.get('pillar_roots') }}

--- a/salt/system/os/ubuntu.sls
+++ b/salt/system/os/ubuntu.sls
@@ -2,6 +2,7 @@
 
 {% if salt.grains.get('os') == "Ubuntu" %}
 
+  {% if ubuntu.license is defined %}
 ubuntu-pro-license:
   cmd.run:
     - name: sudo pro attach {{ ubuntu.license }}
@@ -10,5 +11,10 @@ ubuntu-pro-license:
         cmd: pro status --format json | jq '.attached == true'
         python_shell: True
         output_loglevel: quiet # prevent printing expected log errors
+  {% else %}
+ubuntu-pro-license-not-defined:
+  test.show_notification:
+    - text: There is no Ubuntu license defined under 'pillar/personal/init.sls'. Skipping license configuration.
+  {% endif %}
 
 {% endif %}

--- a/salt/vagrant/init.sls
+++ b/salt/vagrant/init.sls
@@ -1,2 +1,3 @@
 include:
   - .install
+  - .plugins

--- a/salt/vagrant/map.jinja
+++ b/salt/vagrant/map.jinja
@@ -1,0 +1,17 @@
+{% from "personal/map.jinja" import account with context %}
+
+
+{# VAGRANT #}
+{% set _vagrant_pillar = salt.pillar.get('vagrant', {}) %}
+
+
+{# EXTRA #}
+{% set _additional_data = {
+  'user': account.username,
+
+  'supported_kernel': salt.grains.get('os') == "Ubuntu" or salt.grains.get('kernel') == "Darwin",
+} %}
+
+
+{# EXPOSE #}
+{% set vagrant = salt.slsutil.merge_all([_vagrant_pillar, _additional_data]) %}

--- a/salt/vagrant/plugins.sls
+++ b/salt/vagrant/plugins.sls
@@ -1,0 +1,20 @@
+{% from "vagrant/map.jinja" import vagrant with context %}
+
+{% if vagrant.supported_kernel %}
+
+  {% for plugin in vagrant.plugins %}
+
+vagrant-install-{{ plugin }}:
+  cmd.run:
+    - name: vagrant plugin install --no-tty {{ plugin }}
+    - runas: {{ vagrant.user }}
+    - unless:
+      - fun: cmd.run
+        cmd: vagrant plugin list | grep {{ plugin }}
+        runas: {{ vagrant.user }}
+        python_shell: True
+        output_loglevel: quiet # prevent printing expected log errors
+
+  {% endfor %}
+
+{% endif %}

--- a/salt/vscode/extensions.sls
+++ b/salt/vscode/extensions.sls
@@ -1,5 +1,8 @@
 {% from "vscode/map.jinja" import vscode with context %}
 
+include:
+  - .install
+
 {% if vscode.supported_kernel %}
 
 ## TODO [FUN] Create custom module and state to manage vscode basic CLI or bulk install
@@ -16,6 +19,8 @@ vscode-install-{{ extension }}:
         runas: {{ vscode.user }}
         python_shell: True
         output_loglevel: quiet # prevent printing expected log errors
+    - require:
+      - vscode-install
 
   {% endfor %}
 

--- a/salt/vscode/install.sls
+++ b/salt/vscode/install.sls
@@ -5,11 +5,11 @@
 
 vscode-install:
   cmd.run:
-    - name: snap install --classic code
+    - name: sudo snap install --classic code
     - runas: {{ vscode.user }}
     - unless:
       - fun: cmd.run
-        cmd: snap list code
+        cmd: sudo snap list code
         runas: {{ vscode.user }}
         output_loglevel: quiet # prevent printing expected log errors
 


### PR DESCRIPTION
Using Vagrant definitions, add minimal tests for the Ubuntu installation process. This automates the initial startup and GUI installation. Later, we can execute and test the highstate.

There is much to improve, but it should be a nice initial implementation.